### PR TITLE
Evening validation

### DIFF
--- a/lib/pages/ManageSoireesPage.dart
+++ b/lib/pages/ManageSoireesPage.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:stable/constant.dart';
+import 'package:mongo_dart/mongo_dart.dart' as mdb;
+
+class ManageSoireesPage extends StatefulWidget {
+  const ManageSoireesPage({Key? key}) : super(key: key);
+
+  @override
+  _ManageSoireesPageState createState() => _ManageSoireesPageState();
+}
+
+String extractObjectId(String rawId) {
+  var matches = RegExp(r'ObjectId\("([a-fA-F0-9]{24})"\)').firstMatch(rawId);
+  return matches?.group(1) ?? '';
+}
+
+class _ManageSoireesPageState extends State<ManageSoireesPage> {
+  List<Map<String, dynamic>>? soirees;
+  bool isUpdating = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchAllSoirees();
+  }
+
+  Future<void> _fetchAllSoirees() async {
+    var db = mdb.Db(MONGO_URL);
+    await db.open();
+
+    var collection = db.collection('soirees_evenements');
+    List soireesData = await collection.find().toList();
+
+    setState(() {
+      soirees = soireesData.cast<Map<String, dynamic>>();
+    });
+
+    await db.close();
+  }
+
+  Future<void> _updateSoireeStatus(String id, String status) async {
+    setState(() {
+      isUpdating = true;  // Début de la mise à jour
+    });
+
+    var db = mdb.Db(MONGO_URL);
+    await db.open();
+
+    var collection = db.collection('soirees_evenements');
+    var hexId = extractObjectId(id);
+
+    await collection.update(mdb.where.eq("_id", mdb.ObjectId.fromHexString(hexId)), {
+      '\$set': {'status': status}
+    });
+
+    await db.close();
+
+    // Refresh the list
+    _fetchAllSoirees().then((_) {
+      setState(() {
+        isUpdating = false;  // Fin de la mise à jour
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Gérer les soirées')),
+      body: soirees == null
+          ? const Center(child: CircularProgressIndicator())
+          : isUpdating
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+        itemCount: soirees!.length,
+        itemBuilder: (context, index) {
+          var soiree = soirees![index];
+          Color? tileColor;
+          List<Widget> actions = []; // Boutons d'action
+
+          switch (soiree['status']) {
+            case 'ACCEPTED':
+              tileColor = Colors.green[100]; // vert pour validé
+              actions.add(
+                ElevatedButton(
+                  onPressed: null,
+                  style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
+                  child: const Text('Validé'),
+                ),
+              );
+              break;
+            case 'REJECTED':
+              tileColor = Colors.red[100]; // rouge pour refusé
+              actions.add(
+                ElevatedButton(
+                  onPressed: null,
+                  style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                  child: const Text('Refusé'),
+                ),
+              );
+              break;
+            default:
+              tileColor = Colors.grey[100]; // gris pour en attente
+              actions.addAll([
+                ElevatedButton(
+                  onPressed: () {
+                    _updateSoireeStatus(soiree['_id'].toString(), 'ACCEPTED');
+                  },
+                  style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
+                  child: const Text('Valider'),
+                ),
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  onPressed: () {
+                    _updateSoireeStatus(soiree['_id'].toString(), 'REJECTED');
+                  },
+                  style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                  child: const Text('Refuser'),
+                ),
+              ]);
+          }
+
+          return ListTile(
+            tileColor: tileColor,
+            title: Text('${soiree['name']} le ${soiree['date'].toLocal()}'),
+            subtitle: Text('Créateur: ${soiree['createur']}'),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: actions,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'program_cours_page.dart';
 import 'ManageCoursesPage.dart';
+import 'ManageSoireesPage.dart';
 
 class Controller extends GetxController {
   var count = 0.obs;
@@ -45,7 +46,14 @@ class HomePage extends StatelessWidget {
               title: const Text('Gérer les cours'),
               onTap: () {
                 // Naviguez vers ManageCoursesPage
-                Get.to(ManageCoursesPage());
+                Get.to(const ManageCoursesPage());
+              },
+            ),
+            ListTile(
+              title: const Text('Gérer les soirées'),
+              onTap: () {
+                // Naviguez vers ManageSoireesPage
+                Get.to(() => const ManageSoireesPage());
               },
             ),
           ],


### PR DESCRIPTION
## 🚀 Fonctionnalité : Gestion des Soirées 

### Objectif

Permettre aux utilisateurs de **valider** ou de **refuser** une soirée. Cette mise à jour améliore l'expérience utilisateur en rendant la transition fluide, évitant les clignotements inattendus.

### Changements principaux

- 📦 Nouvelle page: `ManageSoireesPage` pour gérer les statuts des soirées.
- 🔌 Intégration avec MongoDB pour récupérer et mettre à jour les données des soirées.
- 🔄 Ajout d'un `CircularProgressIndicator` pour indiquer à l'utilisateur que les données sont en cours de traitement.

### Comment tester cette PR?

1. Naviguez vers la page `Gérer les soirées`.
2. Vous devriez voir la liste des soirées avec leur statut actuel.
3. Essayez de valider ou refuser une soirée. 
4. Assurez-vous que le statut de la soirée est mis à jour sans clignotement.

### Capture d'écran : 
* #### menu hamburger:
![Capture d'écran 2023-10-19 183407](https://github.com/Eduardo-Cerqueira/stable/assets/113473758/2adaac2d-472a-4cb4-8337-78ef64e30ce7)

* Gérer les Soirées
![Capture d'écran 2023-10-19 183353](https://github.com/Eduardo-Cerqueira/stable/assets/113473758/f86d36e8-49d3-40dc-93e7-6e6d7425a3e6)

---

🖋 Auteur: Romain
